### PR TITLE
Single resume path: role curation, delete resume ingest

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -32,8 +32,8 @@
 		<div class="center-content">
 			<div class="icon-block warn">!</div>
 			<h2>No profile loaded</h2>
-			<p class="muted">Parse your resume to get started:</p>
-			<code class="code-block">claude-candidate resume ingest resume.pdf</code>
+			<p class="muted">Onboard your resume to get started:</p>
+			<code class="code-block">claude-candidate resume onboard resume.pdf</code>
 			<button id="btn-retry" class="btn btn-primary">Retry</button>
 		</div>
 	</div>

--- a/src/claude_candidate/cli.py
+++ b/src/claude_candidate/cli.py
@@ -1090,42 +1090,21 @@ def resume() -> None:
     pass
 
 
-@resume.command("ingest")
-@click.argument("resume_path", type=click.Path(exists=True))
-@click.option("--output", "-o", type=click.Path(), default=None,
-              help="Output path for the ResumeProfile JSON. Defaults to ~/.claude-candidate/resume_profile.json")
-def resume_ingest(resume_path: str, output: str | None) -> None:
-    """Parse a resume file and save the structured profile."""
-    from claude_candidate.resume_parser import ingest_resume
-
-    path = Path(resume_path)
-    click.echo(f"Parsing resume: {path.name}")
-
-    profile = ingest_resume(path)
-
-    # Determine output path
-    if output:
-        out_path = Path(output)
-    else:
-        default_dir = Path.home() / ".claude-candidate"
-        default_dir.mkdir(parents=True, exist_ok=True)
-        out_path = default_dir / "resume_profile.json"
-
-    out_path.write_text(profile.to_json())
-
-    click.echo(f"  Name:        {profile.name or '(not detected)'}")
-    click.echo(f"  Title:       {profile.current_title or '(not detected)'}")
-    click.echo(f"  Location:    {profile.location or '(not detected)'}")
-    click.echo(f"  Roles:       {len(profile.roles)}")
-    click.echo(f"  Skills:      {len(profile.skills)}")
-    if profile.total_years_experience is not None:
-        click.echo(f"  Experience:  ~{profile.total_years_experience:.1f} years")
-    click.echo(f"  Hash:        {profile.source_file_hash[:16]}...")
-    click.echo(f"\nProfile written to {out_path}")
-
 
 DEPTH_KEYS = {"1": "mentioned", "2": "used", "3": "applied", "4": "deep", "5": "expert"}
 DEPTH_LABELS = "1=mentioned 2=used 3=applied 4=deep 5=expert"
+
+DOMAIN_HINTS: dict[str, str] = {
+	"education": "edtech", "learning": "edtech", "school": "edtech",
+	"fitness": "healthtech", "health": "healthtech", "medical": "healthtech",
+	"finance": "fintech", "banking": "fintech", "payment": "fintech",
+	"e-commerce": "ecommerce", "retail": "ecommerce", "shop": "ecommerce",
+	"security": "cybersecurity", "auth": "cybersecurity",
+	"game": "gaming", "entertainment": "media",
+	"data": "data-platform", "analytics": "data-platform",
+	"cloud": "cloud-infrastructure", "devops": "cloud-infrastructure",
+	"ai": "ai/ml", "machine learning": "ai/ml", "llm": "ai/ml",
+}
 
 
 def _prompt_depth(skill_name: str, default: str) -> str:
@@ -1206,6 +1185,54 @@ def resume_onboard(resume_path: str, output: str | None, accept_defaults: bool) 
         f"{v} {k}" for k, v in sorted(depths.items(), key=lambda x: -x[1])
     ))
 
+    # Role curation — fill in domain + technologies for each role
+    curated_roles = []
+    if raw_profile.roles:
+        curated_skill_names = [s["name"].lower() for s in curated_skills]
+        if not accept_defaults:
+            click.echo("\nNow let's fill in role details.")
+        for i, role in enumerate(raw_profile.roles, 1):
+            search_text = (role.description + " " + " ".join(role.achievements)).lower()
+            end_label = role.end_date or "present"
+
+            # Infer domain: first keyword match wins
+            inferred_domain = ""
+            for keyword, domain in DOMAIN_HINTS.items():
+                if keyword in search_text:
+                    inferred_domain = domain
+                    break
+
+            # Infer technologies: curated skills mentioned in role text, plus parser-detected
+            inferred_techs: list[str] = [n for n in curated_skill_names if n in search_text]
+            for t in role.technologies:
+                if t.lower() not in inferred_techs:
+                    inferred_techs.append(t.lower())
+
+            if accept_defaults:
+                final_domain = inferred_domain or role.domain or ""
+                final_techs = inferred_techs or list(role.technologies)
+            else:
+                click.echo(f"\n({i}/{len(raw_profile.roles)}) {role.title} @ {role.company} ({role.start_date}–{end_label})")
+                if role.description:
+                    click.echo(f"  {role.description[:120]}")
+                final_domain = click.prompt(
+                    "  Domain",
+                    default=inferred_domain or role.domain or "",
+                    show_default=True,
+                ).strip()
+                tech_default = ", ".join(inferred_techs)
+                tech_input = click.prompt(
+                    "  Technologies (comma-separated)",
+                    default=tech_default,
+                    show_default=True,
+                ).strip()
+                final_techs = [t.strip() for t in tech_input.split(",") if t.strip()]
+
+            role_dict = role.model_dump(mode="json")
+            role_dict["domain"] = final_domain or None
+            role_dict["technologies"] = final_techs
+            curated_roles.append(role_dict)
+
     # Save curated profile — validate at write time to catch onboard bugs
     from claude_candidate.schemas.curated_resume import CuratedResume
 
@@ -1220,7 +1247,7 @@ def resume_onboard(resume_path: str, output: str | None, accept_defaults: bool) 
         name=raw_profile.name,
         current_title=raw_profile.current_title,
         location=raw_profile.location,
-        roles=raw_profile.roles,
+        roles=curated_roles if raw_profile.roles else raw_profile.roles,
         total_years_experience=raw_profile.total_years_experience,
         education=raw_profile.education,
         certifications=raw_profile.certifications,

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 
 from claude_candidate.schemas.candidate_profile import DepthLevel
 from claude_candidate.schemas.merged_profile import EvidenceSource
@@ -207,6 +208,78 @@ def test_merge_with_curated_resume(candidate_profile):
     # Verify total_years and education propagated
     assert merged.total_years_experience == 12.4
     assert "B.S. Computer Science" in merged.education
+
+
+def test_merge_with_curated_passes_roles(candidate_profile):
+    """merge_with_curated should propagate roles with domain/technologies into merged profile."""
+    from datetime import datetime
+    from claude_candidate.merger import merge_with_curated
+    from claude_candidate.schemas.curated_resume import CuratedResume
+
+    curated = CuratedResume(
+        parsed_at=datetime.now(),
+        source_file_hash="test-hash",
+        source_format="pdf",
+        total_years_experience=10.0,
+        education=[],
+        curated_skills=[
+            {"name": "python", "depth": "deep", "source_context": "skills"},
+        ],
+        roles=[
+            {
+                "title": "Senior Engineer",
+                "company": "Acme Corp",
+                "start_date": "2020-01",
+                "end_date": "2023-06",
+                "duration_months": 42,
+                "description": "Built data pipelines for edtech platform",
+                "technologies": ["python", "postgresql"],
+                "achievements": ["Scaled pipeline to 1M events/day"],
+                "domain": "edtech",
+            }
+        ],
+    )
+
+    merged = merge_with_curated(candidate_profile, curated)
+
+    assert len(merged.roles) == 1
+    assert merged.roles[0].domain == "edtech"
+    assert "python" in merged.roles[0].technologies
+
+
+def test_merge_with_curated_no_roles_defaults_empty(candidate_profile):
+    """merge_with_curated with no roles should produce empty roles list."""
+    from datetime import datetime
+    from claude_candidate.merger import merge_with_curated
+    from claude_candidate.schemas.curated_resume import CuratedResume
+
+    curated = CuratedResume(
+        parsed_at=datetime.now(),
+        source_file_hash="test-hash",
+        source_format="pdf",
+        curated_skills=[
+            {"name": "python", "depth": "used", "source_context": "skills"},
+        ],
+    )
+
+    merged = merge_with_curated(candidate_profile, curated)
+    assert merged.roles == []
+
+
+def test_merge_with_curated_malformed_role_skipped(candidate_profile):
+    """Malformed role dicts in CuratedResume should raise validation error at construction time."""
+    from datetime import datetime
+    from pydantic import ValidationError
+    from claude_candidate.schemas.curated_resume import CuratedResume
+
+    with pytest.raises(ValidationError):
+        CuratedResume(
+            parsed_at=datetime.now(),
+            source_file_hash="test-hash",
+            source_format="pdf",
+            curated_skills=[],
+            roles=[{"bad": "data"}],  # missing required fields
+        )
 
 
 def test_corroboration_with_name_variants(candidate_profile):


### PR DESCRIPTION
## Summary

- **Plan 2** from the v0.5 execution sequence
- Add domain + technology curation prompts to `resume onboard` (fills `ResumeRole.domain` and `technologies` via user confirmation)
- Delete `resume ingest` command — `resume onboard` is now the single resume entry point
- Update extension popup to reference `resume onboard`
- Add 3 merger tests for role propagation via `CuratedResume`

## Benchmark checkpoint

17/24 exact | 24/24 within-1 | must-have 92% — unchanged (expected: roles were already flowing through merger)

## Test plan

- [x] `tests/test_merger.py` — 30 passed
- [x] Full suite — 1062 passed, 9 skipped
- [x] Benchmark — 17/24, no regression