### PR TITLE
Soft skill discount 0.3→0.5 with culture signal modulation

### DIFF
--- a/src/claude_candidate/quick_match.py
+++ b/src/claude_candidate/quick_match.py
@@ -147,11 +147,35 @@ MAX_RESUME_ITEMS = 3
 MAX_ACTION_ITEMS = 6
 
 # Soft skill discount factor — reduces weight of soft skill requirements
-SOFT_SKILL_DISCOUNT = 0.3
+SOFT_SKILL_DISCOUNT = 0.5
+SOFT_SKILL_MAX_BOOST = 0.8  # maximum discount when culture signals fully align
 
 # Rounding precision
 SCORE_PRECISION = 3
 TIMING_PRECISION = 2
+
+
+def _soft_skill_discount(
+    culture_signals: list[str] | None,
+    company_profile: "CompanyProfile | None",
+) -> float:
+    """Compute soft skill weight discount, modulated by culture signal strength.
+
+    Base discount is SOFT_SKILL_DISCOUNT (0.5). When a CompanyProfile with
+    culture_keywords is available, the discount is boosted up to SOFT_SKILL_MAX_BOOST (0.8)
+    based on the overlap ratio between posting culture_signals and company culture_keywords.
+    """
+    if not company_profile or not company_profile.culture_keywords:
+        return SOFT_SKILL_DISCOUNT
+    if not culture_signals:
+        return SOFT_SKILL_DISCOUNT
+    company_kw = {kw.lower() for kw in company_profile.culture_keywords}
+    posting_signals = {s.lower() for s in culture_signals}
+    if not posting_signals:
+        return SOFT_SKILL_DISCOUNT
+    overlap = len(posting_signals & company_kw)
+    ratio = overlap / len(posting_signals)
+    return SOFT_SKILL_DISCOUNT + ratio * (SOFT_SKILL_MAX_BOOST - SOFT_SKILL_DISCOUNT)
 
 
 # ---------------------------------------------------------------------------
@@ -1306,6 +1330,8 @@ class QuickMatchEngine:
         start_time = time.time()
         skill_dim, skill_details = self._score_skill_match(
             inp.requirements, inp.seniority,
+            culture_signals=inp.culture_signals,
+            company_profile=inp.company_profile,
         )
         experience_dim = self._score_experience_match(
             inp.requirements, inp.seniority,
@@ -1454,6 +1480,8 @@ class QuickMatchEngine:
         self,
         requirements: list[QuickRequirement],
         seniority: str,
+        culture_signals: list[str] | None = None,
+        company_profile: CompanyProfile | None = None,
     ) -> tuple[DimensionScore, list[SkillMatchDetail]]:
         """Score the skill gap analysis dimension."""
         depth_floor = SENIORITY_DEPTH_FLOOR.get(seniority, DepthLevel.APPLIED)
@@ -1461,6 +1489,7 @@ class QuickMatchEngine:
         weighted_score = 0.0
         total_weight = 0.0
         taxonomy = _get_taxonomy()
+        effective_discount = _soft_skill_discount(culture_signals, company_profile)
 
         for req in requirements:
             weight = PRIORITY_WEIGHT.get(req.priority, 1.0)
@@ -1473,7 +1502,7 @@ class QuickMatchEngine:
                     is_soft_skill = True
                     break
             if is_soft_skill:
-                weight *= SOFT_SKILL_DISCOUNT
+                weight *= effective_discount
 
             total_weight += weight
             best_match, best_status = _find_best_skill(

--- a/tests/test_quick_match.py
+++ b/tests/test_quick_match.py
@@ -1202,3 +1202,79 @@ def test_adaptability_fallback_to_years():
 	assert result.source == EvidenceSource.RESUME_ONLY
 	assert result.effective_depth == DepthLevel.DEEP
 	assert result.confidence == 0.6
+
+
+# ---------------------------------------------------------------------------
+# Soft Skill Discount Modulation Tests (Plan 8)
+# ---------------------------------------------------------------------------
+
+def test_soft_skill_discount_baseline():
+	"""SOFT_SKILL_DISCOUNT constant should be 0.5."""
+	from claude_candidate.quick_match import SOFT_SKILL_DISCOUNT
+	assert SOFT_SKILL_DISCOUNT == 0.5
+
+
+def test_soft_skill_discount_no_company_profile():
+	"""No company profile returns baseline discount."""
+	from claude_candidate.quick_match import _soft_skill_discount, SOFT_SKILL_DISCOUNT
+	assert _soft_skill_discount(None, None) == SOFT_SKILL_DISCOUNT
+	assert _soft_skill_discount(["collaborative"], None) == SOFT_SKILL_DISCOUNT
+
+
+def test_soft_skill_discount_empty_culture_keywords():
+	"""Company profile with empty culture_keywords returns baseline."""
+	from claude_candidate.quick_match import _soft_skill_discount, SOFT_SKILL_DISCOUNT
+	from claude_candidate.schemas.company_profile import CompanyProfile
+	cp = CompanyProfile(company_name="Test Co", product_description="", product_domain=[], enriched_at=datetime.now(), culture_keywords=[])
+	assert _soft_skill_discount(["collaborative"], cp) == SOFT_SKILL_DISCOUNT
+
+
+def test_soft_skill_discount_no_culture_signals():
+	"""None or empty culture signals returns baseline even with company profile."""
+	from claude_candidate.quick_match import _soft_skill_discount, SOFT_SKILL_DISCOUNT
+	from claude_candidate.schemas.company_profile import CompanyProfile
+	cp = CompanyProfile(company_name="Test Co", product_description="", product_domain=[], enriched_at=datetime.now(), culture_keywords=["collaborative", "fast-paced"])
+	assert _soft_skill_discount(None, cp) == SOFT_SKILL_DISCOUNT
+	assert _soft_skill_discount([], cp) == SOFT_SKILL_DISCOUNT
+
+
+def test_soft_skill_discount_full_overlap():
+	"""All posting signals match company keywords returns max boost."""
+	from claude_candidate.quick_match import _soft_skill_discount, SOFT_SKILL_MAX_BOOST
+	from claude_candidate.schemas.company_profile import CompanyProfile
+	cp = CompanyProfile(company_name="Test Co", product_description="", product_domain=[], enriched_at=datetime.now(), culture_keywords=["collaborative", "fast-paced"])
+	result = _soft_skill_discount(["collaborative", "fast-paced"], cp)
+	assert result == SOFT_SKILL_MAX_BOOST
+
+
+def test_soft_skill_discount_partial_overlap():
+	"""2/4 signals match → discount = 0.5 + 0.5 * 0.3 = 0.65."""
+	from claude_candidate.quick_match import _soft_skill_discount
+	from claude_candidate.schemas.company_profile import CompanyProfile
+	cp = CompanyProfile(
+		company_name="Test Co",
+		product_description="",
+		product_domain=[],
+		enriched_at=datetime.now(),
+		culture_keywords=["collaborative", "fast-paced"],
+	)
+	result = _soft_skill_discount(["collaborative", "fast-paced", "autonomous", "mission-driven"], cp)
+	assert abs(result - 0.65) < 0.001
+
+
+def test_soft_skill_discount_zero_overlap():
+	"""Signals present but none match company keywords returns baseline."""
+	from claude_candidate.quick_match import _soft_skill_discount, SOFT_SKILL_DISCOUNT
+	from claude_candidate.schemas.company_profile import CompanyProfile
+	cp = CompanyProfile(company_name="Test Co", product_description="", product_domain=[], enriched_at=datetime.now(), culture_keywords=["collaborative"])
+	result = _soft_skill_discount(["autonomous", "mission-driven"], cp)
+	assert result == SOFT_SKILL_DISCOUNT
+
+
+def test_soft_skill_discount_case_insensitive():
+	"""'Collaborative' matches 'collaborative' regardless of case."""
+	from claude_candidate.quick_match import _soft_skill_discount, SOFT_SKILL_MAX_BOOST
+	from claude_candidate.schemas.company_profile import CompanyProfile
+	cp = CompanyProfile(company_name="Test Co", product_description="", product_domain=[], enriched_at=datetime.now(), culture_keywords=["Collaborative"])
+	result = _soft_skill_discount(["collaborative"], cp)
+	assert result == SOFT_SKILL_MAX_BOOST


### PR DESCRIPTION
## Summary

- **Plan 8** from the v0.5 execution sequence
- Raises `SOFT_SKILL_DISCOUNT` from 0.3 to 0.5 (baseline for all assessments)
- Adds `SOFT_SKILL_MAX_BOOST = 0.8` for full culture signal alignment
- Adds `_soft_skill_discount()`: interpolates 0.5→0.8 based on overlap ratio between posting culture_signals and company `culture_keywords`
- Threads `culture_signals` and `company_profile` into `_score_skill_match()`

## Benchmark checkpoint

**18/24 exact** | 24/24 within-1 | must-have 92% — one improvement over baseline (17/24). Soft skill requirements now count more, boosting a posting that had soft skill must-haves.

## Test plan

- [x] 8 new `_soft_skill_discount` unit tests covering all edge cases
- [x] Full suite — 1087 passed, 9 skipped
- [x] Benchmark — 18/24, improvement confirmed