### PR TITLE
chore: gitignore .claude/handoffs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ htmlcov/
 
 # Generated static site
 site/
+.claude/handoffs/


### PR DESCRIPTION
Adds `.claude/handoffs/` to `.gitignore` so session handoff documents and transcripts generated by the `/handoff` skill are never accidentally staged.