### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "claude-candidate",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Honest, evidence-backed job fit assessments from your Claude Code session logs",
   "permissions": ["activeTab", "tabs", "storage", "scripting"],
   "host_permissions": ["http://localhost:7429/*", "https://www.linkedin.com/*"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-candidate"
-version = "0.5.0"
+version = "0.6.0"
 description = "Privacy-first pipeline: Claude Code session logs + resume → honest, evidence-backed job fit assessments"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps `pyproject.toml` and `extension/manifest.json` from `0.5.0` → `0.6.0`.

Covers PRs #23–#29: eligibility gates, corpus management, match_type, domain-penalty, and confidence overhaul.