### PR TITLE
chore: bump version to 0.8.3

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "claude-candidate",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Honest, evidence-backed job fit assessments from your Claude Code session logs",
   "permissions": ["activeTab", "tabs", "storage", "scripting"],
   "host_permissions": ["http://localhost:7429/*"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-candidate"
-version = "0.8.2"
+version = "0.8.3"
 description = "Privacy-first pipeline: Claude Code session logs + resume → honest, evidence-backed job fit assessments"
 readme = "README.md"
 license = "MIT"

--- a/src/claude_candidate/__init__.py
+++ b/src/claude_candidate/__init__.py
@@ -3,4 +3,4 @@ claude-candidate: Privacy-first pipeline that transforms Claude Code session log
 and resume credentials into honest, evidence-backed job fit assessments.
 """
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"


### PR DESCRIPTION
## Summary

- Version bump to 0.8.3 across pyproject.toml, manifest.json, and __init__.py
- Go-public release tag follows after merge

## Test plan

- [x] No code changes, version strings only