### PR TITLE
fix: anonymize remaining PII in resume fixture

### DIFF
--- a/tests/fixtures/sample_resume.txt
+++ b/tests/fixtures/sample_resume.txt
@@ -1,4 +1,4 @@
-BRIAN RUGGIERI
+ALEX DEVELOPER
 Senior Software Engineer
 San Francisco, CA
 

--- a/tests/test_resume_parser.py
+++ b/tests/test_resume_parser.py
@@ -17,7 +17,7 @@ class TestTextExtraction:
 		from claude_candidate.resume_parser import extract_text_from_file
 
 		text = extract_text_from_file(SAMPLE_RESUME)
-		assert "BRIAN RUGGIERI" in text
+		assert "ALEX DEVELOPER" in text
 		assert "Senior Software Engineer" in text
 		assert "TechCorp" in text
 		assert "Python" in text
@@ -72,7 +72,7 @@ class TestResumeTextParsing:
 
 		profile = parse_resume_text(sample_text)
 		assert profile.name is not None
-		assert "BRIAN" in profile.name.upper() or "Brian" in profile.name
+		assert "ALEX" in profile.name.upper() or "Alex" in profile.name
 
 	def test_extracts_location(self, sample_text):
 		from claude_candidate.resume_parser import parse_resume_text


### PR DESCRIPTION
## Summary

- `BRIAN RUGGIERI` → `ALEX DEVELOPER` in `tests/fixtures/sample_resume.txt`
- Updated 2 assertions in `tests/test_resume_parser.py` to match

Missed in PR #40 because the original scan was case-sensitive and the resume fixture uses ALL CAPS.

## Test plan

- [x] 1,318 passed, 27 skipped
- [x] `git grep -i "Brian Ruggieri"` clean (excluding LICENSE, pyproject.toml, docs/superpowers/)